### PR TITLE
DM-12129: Update the DPDD to clean up the discussion of maggies vs. Janskys

### DIFF
--- a/dpdd.tex
+++ b/dpdd.tex
@@ -54,10 +54,9 @@
 M. Juri\'c,
 T.~Axelrod, A.C.~Becker, J.~Becla, E.~Bellm, J.F.~Bosch, D.~Ciardi,
 A.J.~Connolly,  G.P.~Dubois-Felsmann, F.~Economou, M.~Freemon,
-M.~Gelman, R.~Gill, M.~Graham, \newtext{L.P.~Guy,} \v{Z}.~Ivezi\'c, T.~Jenness,  J.~Kantor, K.S.~Krughoff,
+M.~Gelman, R.~Gill, M.~Graham, L.P.~Guy, \v{Z}.~Ivezi\'c, T.~Jenness,  J.~Kantor, K.S.~Krughoff,
 K-T~Lim,  R.H.~Lupton, F.~Mueller, D.~Nidever, W.~O'Mullane, M.~Patterson,
-D.~Petravick, D. Shaw,
-C.~Slater, M.~Strauss, J.~Swinbank, J.A.~Tyson, M.~Wood-Vasey, and X.~Wu
+D.~Petravick, D. Shaw, C.~Slater, M.~Strauss, J.~Swinbank, J.A.~Tyson, M.~Wood-Vasey, and X.~Wu
 }
 
 \date{\today}


### PR DESCRIPTION
This implements the recommendation from the PST that catalogs be served in nanojanskys rather than nanomaggies.