### PR TITLE
Update lsst-texmf submodule to main and rebuild acronyms.

### DIFF
--- a/acronyms.tex
+++ b/acronyms.tex
@@ -21,32 +21,38 @@ FITS & Flexible Image Transport System \\\hline
 IVOA & International Virtual-Observatory Alliance \\\hline
 LCR & LSST Change Request \\\hline
 LDM & LSST Data Management (Document Handle) \\\hline
-LDO & LSST Document Operations (Document Handle) \\\hline
 LPM & LSST Project Management (Document Handle) \\\hline
 LSE & LSST Systems Engineering (Document Handle) \\\hline
 LSR & LSST System Requirements; LSE-29 \\\hline
 LSST & Legacy Survey of Space and Time (formerly Large Synoptic Survey Telescope) \\\hline
+ML & Machine Learning \\\hline
 MPC & Minor Planet Center \\\hline
 NCSA & National Center for Supercomputing Applications \\\hline
+NGC & New General Catalogue \\\hline
 OSS & Observatory System Specifications; LSE-30 \\\hline
 PB & PetaByte \\\hline
 PCA & Principal Component Analysis \\\hline
 PPDB & Prompt Products DataBase \\\hline
 PSF & Point Spread Function \\\hline
+RDO & Rubin Directors Office \\\hline
 RFC & Request For Comment \\\hline
+RGB & Red Giant Branch \\\hline
 SAC & Science Advisory Committee \\\hline
 SDSS & Sloan Digital Sky Survey \\\hline
 SE & System Engineering \\\hline
 SED & Spectral Energy Distribution \\\hline
+SNR & Signal to Noise Ratio \\\hline
 SQL & Structured Query Language \\\hline
 SRD & LSST Science Requirements; LPM-17 \\\hline
 SS & Subsystem Scientist \\\hline
 SSP & Solar System Processing \\\hline
 TAC & Time Allocation Committee \\\hline
 TBD & To Be Defined (Determined) \\\hline
+UDF & User Defined Function \\\hline
 UML & unified modeling language \\\hline
 WAN & Wide Area Network \\\hline
 WCS & World Coordinate System \\\hline
 arcsec & arcsecond second of arc (unit of angle) \\\hline
 deg & degree; unit of angle \\\hline
+photo-z & photometric redshift \\\hline
 \end{longtable}


### PR DESCRIPTION
Submodule update is necessary for this to build against recent LaTeX distributions.

I saw that the acronyms were updated, too, after rebuilding, so I made that another commit; I'm not sure if it should be included here or not.